### PR TITLE
Add inlay hint color

### DIFF
--- a/themes/Oceanic Plus Plus-color-theme.json
+++ b/themes/Oceanic Plus Plus-color-theme.json
@@ -82,7 +82,9 @@
     "textLink.foreground": "#5fb3b3",
     "titleBar.activeBackground": "#0d151a",
     "titleBar.inactiveBackground": "#0d151a",
-    "widget.shadow": "#0005"
+    "widget.shadow": "#0005",
+    "editorInlayHint.background": "#00000000",
+    "editorInlayHint.foreground": "#65737e"
   },
   "tokenColors": [
     {
@@ -292,7 +294,10 @@
       }
     },
     {
-      "scope": ["keyword.operator.or.regexp", "keyword.control.anchor.regexp"],
+      "scope": [
+        "keyword.operator.or.regexp",
+        "keyword.control.anchor.regexp"
+      ],
       "settings": {
         "foreground": "#FAC863"
       }


### PR DESCRIPTION
This PR sets inlay hints to use the same text color as comments, and a transparent background. Currently this theme doesn't support inlay hints, so the (ugly) VSCode default colors are used.